### PR TITLE
Utilize the strength of pcm-util 3.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,8 @@ PCMFormat.prototype._transform = function (inputChunk, enc, cb) {
 		});
 
 		cb(null, outputChunk);
+	} else {
+		cb();
 	}
 };
 

--- a/index.js
+++ b/index.js
@@ -26,10 +26,6 @@ function PCMFormat (input, output) {
         }
     }
     if (eq) return new PassThrough();
-
-    //precalc formats
-    this.input = util.normalize(this.input);
-    this.output = util.normalize(this.output);
 }
 
 inherits(PCMFormat, Through);

--- a/index.js
+++ b/index.js
@@ -2,119 +2,59 @@
  * @module audio-pcm-format
  */
 
-
 var inherits = require('inherits');
-var Transform = require('stream').Transform;
-var PassThrough = require('stream').PassThrough;
-var extend = require('xtend/mutable');
+var Through = require('audio-through');
 var util = require('pcm-util');
-
+var extend = require('xtend/mutable');
 
 /** @constructor */
 function PCMFormat (input, output) {
-	if (!(this instanceof PCMFormat)) return new PCMFormat(input, output);
+    if (!(this instanceof PCMFormat)) return new PCMFormat(input, output);
 
-	Transform.call(this);
+    Through.call(this, output);
 
-	//save input format
-	this.input = extend({}, PCMFormat.default, input);
-	this.output = extend({}, PCMFormat.default, output);
+    //save input format
+    this.input = extend({}, PCMFormat.default, input);
+    this.output = extend({}, PCMFormat.default, output);
 
-	//if input format === output format - return passthrough stream
-	var eq = true;
-	for (var key in this.input) {
-		if (this.input[key] !== this.output[key]) {
-			eq = false;
-			break;
-		}
-	}
-	if (eq) return new PassThrough();
+    //if input format === output format - return passthrough stream
+    var eq = true;
+    for (var key in this.input) {
+        if (this.input[key] !== this.output[key]) {
+            eq = false;
+            break;
+        }
+    }
+    if (eq) return new PassThrough();
 
-	//precalc formats
-	this.input = util.normalizeFormat(this.input);
-	this.output = util.normalizeFormat(this.output);
-
-	//convert channels to arrays, if mapping is required
-	this.input.channels = PCMFormat.getChannelsMap(this.input.channels);
-	this.output.channels = PCMFormat.getChannelsMap(this.output.channels);
-
-	//normalized data for output channels
-	this.data = this.output.channels.map(function () {return []});
+    //precalc formats
+    this.input = util.normalize(this.input);
+    this.output = util.normalize(this.output);
 }
 
-inherits(PCMFormat, Transform);
+inherits(PCMFormat, Through);
 
 
-PCMFormat.prototype._transform = function (inputChunk, enc, cb) {
-	var self = this;
-	var input = self.input, output = self.output, data = self.data;
-	var value, channel, offset, channels;
+PCMFormat.prototype.process = function (buffer) {
+    var self = this;
 
-	var inputFrameLength = inputChunk.length / input.sampleSize / input.channels.length;
-	var outputFrameLength = output.samplesPerFrame || inputFrameLength;
+    var input = self.input, output = self.output;
+    var out = util.convert(util.toArrayBuffer(buffer), input, output);
 
-	var sampleRateRatio = input.sampleRate / output.sampleRate;
-
-
-	//bring value to normalized form
-	channels = input.channels;
-	for (var i = 0; i < inputFrameLength; i++) {
-		for (var cIdx = 0; cIdx < channels.length; cIdx++) {
-			channel = channels[cIdx];
-			offset = (input.interleaved ? channel + i * channels.length : channel * inputFrameLength + i) * input.sampleSize;
-			value = inputChunk[input.readMethodName](offset);
-
-			//put recalculated value to the proper channel
-			data[channel].push(util.convertSample(value, input, output));
-		}
-	}
-
-
-	//if there is enough data - send chunk
-	channels = output.channels;
-
-	if (!output.samplesPerFrame || (output.samplesPerFrame && self.data[channel].length > output.samplesPerFrame)) {
-		var outputChunkSize = outputFrameLength * output.sampleSize * channels.length;
-		var outputChunk = new Buffer(outputChunkSize);
-
-		//write sample
-		for (var i = 0; i < outputFrameLength; i++) {
-			for (var cIdx = 0; cIdx < channels.length; cIdx++) {
-				channel = channels[cIdx];
-
-				//pick resampled value
-				value = data[channel][Math.round(i * sampleRateRatio)];
-
-				//write value to proper position
-				offset = (output.interleaved ? channel + i * channels.length : channel * outputFrameLength + i) * output.sampleSize;
-
-				outputChunk[output.writeMethodName](value, offset);
-			}
-		}
-
-		//shorten inner data on the input frame size, inc sample rate
-		self.data = self.data.map(function (data) {
-			return data.slice(Math.round(outputFrameLength * sampleRateRatio));
-		});
-
-		cb(null, outputChunk);
-	} else {
-		cb();
-	}
+    return Buffer.from(out);
 };
 
 
 /** Generate channels array from number of channels */
 PCMFormat.getChannelsMap = function (n) {
-	if (!Array.isArray(n)) {
-		var result = [];
-		for (var i = 0; i < n; i++) {
-			result[i] = i;
-		}
-	}
-	return result;
+    if (!Array.isArray(n)) {
+        var result = [];
+        for (var i = 0; i < n; i++) {
+            result[i] = i;
+        }
+    }
+    return result;
 };
-
 
 /** Default PCM settings. Technically redefinable. */
 PCMFormat.default = extend({}, util.defaultFormat);

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "mocha": "^2.3.3"
   },
   "dependencies": {
+    "audio-through": "^2.2.3",
     "inherits": "^2.0.1",
-    "pcm-util": "^1.1.10",
+    "pcm-util": "^3.0.0",
     "xtend": "^4.0.0"
   }
 }


### PR DESCRIPTION
Using the more modern version of `pcm-util` and `audio-through` drastically simplifies this package.